### PR TITLE
fix: double submit for edit and add reicpe, parse recipe validation, img

### DIFF
--- a/src/app/_lib/recipe/CreateForm2.tsx
+++ b/src/app/_lib/recipe/CreateForm2.tsx
@@ -20,6 +20,7 @@ export function Stage2Form() {
         onChange={(e) => setUrl(e.target.value)}
         required
         className="w-full"
+        pattern="[Hh][Tt][Tt][Pp][Ss]?:\/\/(?:(?:[a-zA-Z\u00a1-\uffff0-9]+-?)*[a-zA-Z\u00a1-\uffff0-9]+)(?:\.(?:[a-zA-Z\u00a1-\uffff0-9]+-?)*[a-zA-Z\u00a1-\uffff0-9]+)*(?:\.(?:[a-zA-Z\u00a1-\uffff]{2,}))(?::\d{2,5})?(?:\/[^\s]*)?"
       />
       <div className="flex justify-end gap-2">
         <Link

--- a/src/app/_lib/recipe/EditForm.tsx
+++ b/src/app/_lib/recipe/EditForm.tsx
@@ -68,7 +68,11 @@ export function EditForm({
     removeFile();
   };
   const queryUtils = api.useUtils();
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const editRecipe = api.recipes.editRecipe.useMutation({
+    onError() {
+      setIsSubmitting(false);
+    },
     async onSuccess(presignedPost) {
       if (!presignedPost) {
         snackbarDispatch({
@@ -80,12 +84,12 @@ export function EditForm({
         return;
       }
       if (!file) {
-        console.log("file is missing");
-        // error unable to upload file or user somehow removed img after upload
+        // Didn't update image
         snackbarDispatch({
           type: "ERROR",
           message: "There was a problem with uploading your image",
         });
+        setIsSubmitting(false);
         return;
       }
       // Add fields that are required for presigned post
@@ -117,11 +121,15 @@ export function EditForm({
           type: "ERROR",
           message: "There was a problem with uploading your image",
         });
+        setIsSubmitting(false);
       }
     },
   });
   const editUrlImageRecipeMutation = api.recipes.editUrlImageRecipe.useMutation(
     {
+      onError() {
+        setIsSubmitting(false);
+      },
       async onSuccess() {
         snackbarDispatch({
           type: "SUCCESS",
@@ -143,7 +151,9 @@ export function EditForm({
     if (isUploadedImage && validData.image.imageMetadata) {
       const formattedData = {
         id: params.recipeId as string,
-        updateImage: !!dirtyFields.image?.imageMetadata,
+        updateImage:
+          !!dirtyFields.image?.imageMetadata &&
+          (dirtyFields.image.imageMetadata as unknown as boolean) === true,
         fields: {
           ...validData,
           imageMetadata: validData.image.imageMetadata,
@@ -231,7 +241,7 @@ export function EditForm({
           <SectionWrapper>
             <CookingMethodsSection />
           </SectionWrapper>
-          <Button disabled={editRecipe.isLoading}>Edit</Button>
+          <Button disabled={isSubmitting}>Edit</Button>
         </form>
       </FormProvider>
     </section>

--- a/src/app/_lib/recipe/Form.tsx
+++ b/src/app/_lib/recipe/Form.tsx
@@ -28,7 +28,6 @@ export function RecipeForm({
   initialData: RecipeFormData | undefined;
 }) {
   const usingUploadedImage =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     (data?.initialData && data.initialData.image.urlSourceImage.length == 0) ??
     true;
   const [isUploadedImage, setIsUploadedImage] = useState(usingUploadedImage);
@@ -84,7 +83,11 @@ export function RecipeForm({
     handleFileDrop,
     removeFile,
   } = useImageUpload(setFileMetadata);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const addRecipeMutation = api.recipes.addRecipe.useMutation({
+    onError() {
+      setIsSubmitting(false);
+    },
     async onSuccess(presignedPost) {
       if (!file) {
         // error unable to upload file or user somehow removed img after upload
@@ -92,6 +95,7 @@ export function RecipeForm({
           type: "ERROR",
           message: "There was a problem with uploading your image",
         });
+        setIsSubmitting(false);
         return;
       }
       if (!presignedPost) {
@@ -127,10 +131,14 @@ export function RecipeForm({
           type: "ERROR",
           message: "There was a problem with uploading your image",
         });
+        setIsSubmitting(false);
       }
     },
   });
   const addParsedRecipeMutation = api.recipes.addParsedRecipe.useMutation({
+    onError() {
+      setIsSubmitting(false);
+    },
     onSuccess() {
       snackbarDispatch({
         type: "SUCCESS",
@@ -159,6 +167,7 @@ export function RecipeForm({
       };
       addParsedRecipeMutation.mutate(formattedData);
     }
+    setIsSubmitting(true);
   });
   const navigateToRecipes = () => router.push("/recipes");
   return (
@@ -207,7 +216,7 @@ export function RecipeForm({
           <SectionWrapper>
             <CookingMethodsSection />
           </SectionWrapper>
-          <Button disabled={addRecipeMutation.isLoading}>Create</Button>
+          <Button disabled={isSubmitting}>Create</Button>
         </form>
       </FormProvider>
     </section>

--- a/src/app/_lib/recipe/ListInputField.tsx
+++ b/src/app/_lib/recipe/ListInputField.tsx
@@ -53,7 +53,6 @@ export function ListInput({
           intent="noBoarder"
           type="button"
           onClick={() => {
-            console.log("remove", index);
             remove(index);
           }}
         >

--- a/src/app/recipes/[recipeId]/page.tsx
+++ b/src/app/recipes/[recipeId]/page.tsx
@@ -72,19 +72,23 @@ export default async function RecipePage({
       <section>
         <h2 className="mb-3 text-2xl font-bold">Steps</h2>
         {!!recipe.steps.length ? (
-          <ol className="flex flex-col gap-2">
-            {recipe.steps.map(({ name, isHeader, order }) => (
-              <li
-                key={order}
-                className={
-                  isHeader ? "text-xl font-bold" : "flex items-start gap-2"
-                }
-              >
-                {!isHeader && <span>{order + 1}.</span>}
-                {name}
-              </li>
-            ))}
-          </ol>
+          <ul className="flex flex-col gap-2">
+            {recipe.steps.map((step) => {
+              return (
+                <li
+                  key={step.order}
+                  className={
+                    step.isHeader
+                      ? "text-xl font-bold"
+                      : "flex items-start gap-2"
+                  }
+                >
+                  {step.count !== -1 && <span>{step.count}.</span>}
+                  {step.name}
+                </li>
+              );
+            })}
+          </ul>
         ) : (
           <p>This recipe doesn&apos;t have steps</p>
         )}

--- a/src/app/recipes/create/page.tsx
+++ b/src/app/recipes/create/page.tsx
@@ -32,6 +32,10 @@ export default async function Create({
   noStore();
   const params = searchParamsSchema.safeParse(searchParams);
   if (!params.success) {
+    if (params.error.formErrors.fieldErrors.url) {
+      redirect(`/recipes/create?formStage=2`);
+    }
+
     redirect(`/recipes/create?formStage=1`);
   }
 

--- a/src/server/services/recipesService.ts
+++ b/src/server/services/recipesService.ts
@@ -296,16 +296,34 @@ export async function updateRecipe({
   userId,
 }: {
   ctx: Context;
-  id: EditRecipe["id"];
+  id: string;
   fields: EditRecipe["fields"];
   userId: string;
 }) {
   await ctx.prisma.$transaction(async (prisma) => {
+    await prisma.ingredient.deleteMany({ where: { recipeId: id } });
+    await prisma.step.deleteMany({ where: { recipeId: id } });
     await prisma.recipe.update({
       where: { id, authorId: userId },
       data: {
         name: fields.name,
         description: fields.description,
+        ingredients: {
+          createMany: {
+            data: fields.ingredients.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
+        steps: {
+          createMany: {
+            data: fields.steps.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
         prepTime: fields.prepTime,
         cookTime: fields.cookTime,
       },
@@ -326,6 +344,8 @@ export async function updateRecipeSignedToSigned({
   uuid: string;
 }) {
   await ctx.prisma.$transaction(async (prisma) => {
+    await prisma.ingredient.deleteMany({ where: { recipeId: id } });
+    await prisma.step.deleteMany({ where: { recipeId: id } });
     await prisma.recipe.update({
       where: { id },
       data: {
@@ -333,6 +353,22 @@ export async function updateRecipeSignedToSigned({
         description: fields.description,
         prepTime: fields.prepTime,
         cookTime: fields.cookTime,
+        ingredients: {
+          createMany: {
+            data: fields.ingredients.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
+        steps: {
+          createMany: {
+            data: fields.steps.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
         mainImage: {
           update: {
             metadataImage: {
@@ -364,6 +400,8 @@ export async function updateRecipeUrlToSigned({
   uuid: string;
 }) {
   await ctx.prisma.$transaction(async (prisma) => {
+    await prisma.ingredient.deleteMany({ where: { recipeId: id } });
+    await prisma.step.deleteMany({ where: { recipeId: id } });
     await prisma.recipe.update({
       where: { id },
       data: {
@@ -371,6 +409,22 @@ export async function updateRecipeUrlToSigned({
         description: fields.description,
         prepTime: fields.prepTime,
         cookTime: fields.cookTime,
+        ingredients: {
+          createMany: {
+            data: fields.ingredients.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
+        steps: {
+          createMany: {
+            data: fields.steps.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
         mainImage: {
           update: {
             urlImage: {
@@ -405,13 +459,31 @@ export async function updateRecipeSignedToUrl({
   fields: EditUrlImageRecipe["fields"];
 }) {
   await ctx.prisma.$transaction(async (prisma) => {
-    await ctx.prisma.recipe.update({
+    await prisma.ingredient.deleteMany({ where: { recipeId: id } });
+    await prisma.step.deleteMany({ where: { recipeId: id } });
+    await prisma.recipe.update({
       where: { id },
       data: {
         name: fields.name,
         description: fields.description,
         prepTime: fields.prepTime,
         cookTime: fields.cookTime,
+        ingredients: {
+          createMany: {
+            data: fields.ingredients.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
+        steps: {
+          createMany: {
+            data: fields.steps.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
         mainImage: {
           update: {
             urlImage: {
@@ -442,13 +514,31 @@ export async function updateRecipeUrlToUrl({
   fields: EditUrlImageRecipe["fields"];
 }) {
   await ctx.prisma.$transaction(async (prisma) => {
-    await ctx.prisma.recipe.update({
+    await prisma.ingredient.deleteMany({ where: { recipeId: id } });
+    await prisma.step.deleteMany({ where: { recipeId: id } });
+    await prisma.recipe.update({
       where: { id },
       data: {
         name: fields.name,
         description: fields.description,
         prepTime: fields.prepTime,
         cookTime: fields.cookTime,
+        ingredients: {
+          createMany: {
+            data: fields.ingredients.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
+        steps: {
+          createMany: {
+            data: fields.steps.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
         mainImage: {
           update: {
             urlImage: {
@@ -474,13 +564,31 @@ export async function updateRecipeNoneToUrl({
   fields: EditUrlImageRecipe["fields"];
 }) {
   await ctx.prisma.$transaction(async (prisma) => {
-    await ctx.prisma.recipe.update({
+    await prisma.ingredient.deleteMany({ where: { recipeId: id } });
+    await prisma.step.deleteMany({ where: { recipeId: id } });
+    await prisma.recipe.update({
       where: { id },
       data: {
         name: fields.name,
         description: fields.description,
         prepTime: fields.prepTime,
         cookTime: fields.cookTime,
+        ingredients: {
+          createMany: {
+            data: fields.ingredients.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
+        steps: {
+          createMany: {
+            data: fields.steps.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
         mainImage: {
           create: {
             urlImage: {
@@ -508,6 +616,8 @@ export async function updateRecipeNoneToSigned({
   uuid: string;
 }) {
   await ctx.prisma.$transaction(async (prisma) => {
+    await prisma.ingredient.deleteMany({ where: { recipeId: id } });
+    await prisma.step.deleteMany({ where: { recipeId: id } });
     await prisma.recipe.update({
       where: { id },
       data: {
@@ -515,6 +625,22 @@ export async function updateRecipeNoneToSigned({
         description: fields.description,
         prepTime: fields.prepTime,
         cookTime: fields.cookTime,
+        ingredients: {
+          createMany: {
+            data: fields.ingredients.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
+        steps: {
+          createMany: {
+            data: fields.steps.map(({ id: _, ...rest }, i) => ({
+              ...rest,
+              order: i,
+            })),
+          },
+        },
         mainImage: {
           create: {
             metadataImage: {
@@ -593,6 +719,7 @@ export async function deleteRecipe({ ctx, id }: { ctx: Context; id: string }) {
     await tx.mealTypesOnRecipies.deleteMany({ where: { recipeId: id } });
     await tx.nationalitiesOnRecipes.deleteMany({ where: { recipeId: id } });
     await tx.cookingMethodsOnRecipies.deleteMany({ where: { recipeId: id } });
+    await tx.favouriteRecipe.deleteMany({ where: { recipeId: id } });
     await tx.urlImage.deleteMany({
       where: {
         image: {


### PR DESCRIPTION
- Fix double submit bug where users can create and edit recipes twice clicking create/edit twice quickly
- Fix parse url recipe (create recipe -> parse from url) not validating the url
- Fix updating recipe may delete uploading images in some scenarios (create recipe -> edit recipe -> change order of ingredients -> edit)
- Fix ingredients and steps order not updating after editing
- Fix steps header showing the step (it shouldn't show step number if header)